### PR TITLE
Fix bullet-less bullet lists

### DIFF
--- a/www/styles/base.css
+++ b/www/styles/base.css
@@ -404,6 +404,10 @@ ol li {
 	margin: 1em 0;
 }
 
+ul li {
+	list-style: disc outside;
+}
+
 /* }}} */
 /* {{{ Authors */
 


### PR DESCRIPTION
The bullets are turned off in unordered lists in the YUI Reset CSS. This turns them back on.
